### PR TITLE
Make LJ chain class more flexible, add unit tests

### DIFF
--- a/hoomd_polymers/molecules.py
+++ b/hoomd_polymers/molecules.py
@@ -207,13 +207,13 @@ class LJ_chain(mb.Compound):
     Parameters
     ----------
     length : int; required
-        The number of beads in the polymer chain
-    bond_length : float; required
+        The number of times to repeat bead_sequence in a single chain.
+    bead_sequence : list; optional; default ["A"]
+        The sequence of bead types in the chain.
+    bond_length : dict; optional; default {"A-A": 1.0}
         The bond length between connected beads (units: nm)
-    bead_name : str; optional; default "A"
-        The name of the bead
-    bead_mass : float; optional; default 1.0
-        The mass of the bead
+    bead_mass : dict; optional; default {"A": 1.0} 
+        The mass of the bead types
     """
     def __init__(
             self,

--- a/hoomd_polymers/molecules.py
+++ b/hoomd_polymers/molecules.py
@@ -227,15 +227,19 @@ class LJ_chain(mb.Compound):
         last_bead = None
         for i in range(length):
             for idx, bead_type in enumerate(bead_sequence):
-                next_bead = mb.Compound(
-                        mass=bead_mass[bead_type], name=bead_type, charge=0
-                )
+                mass = bead_mass.get(bead_type, None)
+                if not mass:
+                    raise ValueError(
+                            f"The bead mass for {bead_type} was not given "
+                            "in the bead_mass dict."
+                    )
+                next_bead = mb.Compound(mass=mass, name=bead_type, charge=0)
                 self.add(next_bead)
                 if last_bead:
                     bead_pair = "-".join([last_bead.name, next_bead.name])
-                    bead_pair_rev = "-".join([next_bead.name, last_bead.name])
                     bond_length = bond_lengths.get(bead_pair, None)
                     if not bond_length:
+                        bead_pair_rev = "-".join([next_bead.name, last_bead.name])
                         bond_length = bond_lengths.get(bead_pair_rev, None)
                     if not bond_length:
                         raise ValueError(

--- a/hoomd_polymers/molecules.py
+++ b/hoomd_polymers/molecules.py
@@ -4,6 +4,7 @@ import random
 import mbuild as mb
 from mbuild.coordinate_transform import z_axis_transform
 from mbuild.lib.recipes import Polymer
+import numpy as np
 
 from hoomd_polymers.library import MON_DIR
 
@@ -214,15 +215,35 @@ class LJ_chain(mb.Compound):
     bead_mass : float; optional; default 1.0
         The mass of the bead
     """
-    def __init__(self, length, bond_length, bead_name="A", bead_mass=1.0):
+    def __init__(
+            self,
+            length,
+            bead_sequence=["A"],
+            bead_mass={"A": 1.0},
+            bond_lengths={"A-A": 1.0},
+    ):
         super(LJ_chain, self).__init__()
         self.description = "Simple bead-spring polymer"
-        bead = mb.Compound(mass=bead_mass, name=bead_name)
         last_bead = None
         for i in range(length):
-            next_bead = mb.clone(bead)
-            next_bead.translate((0, 0, bond_length*i))
-            self.add(next_bead)
-            if i != 0:
-                self.add_bond([next_bead, last_bead])
-            last_bead = next_bead
+            for idx, bead_type in enumerate(bead_sequence):
+                next_bead = mb.Compound(
+                        mass=bead_mass[bead_type], name=bead_type, charge=0
+                )
+                self.add(next_bead)
+                if last_bead:
+                    bead_pair = "-".join([last_bead.name, next_bead.name])
+                    bead_pair_rev = "-".join([next_bead.name, last_bead.name])
+                    bond_length = bond_lengths.get(bead_pair, None)
+                    if not bond_length:
+                        bond_length = bond_lengths.get(bead_pair_rev, None)
+                    if not bond_length:
+                        raise ValueError(
+                                "The bond length for pair "
+                                f"{bead_pair} or {bead_pair_rev} "
+                                "is not found in the bond_lengths dict."
+                        )
+                    new_pos = last_bead.xyz[0] + (0, 0, bond_length)
+                    next_bead.translate_to(new_pos)
+                    self.add_bond([next_bead, last_bead])
+                last_bead = next_bead

--- a/hoomd_polymers/molecules.py
+++ b/hoomd_polymers/molecules.py
@@ -241,12 +241,12 @@ class LJ_chain(mb.Compound):
                     if not bond_length:
                         bead_pair_rev = "-".join([next_bead.name, last_bead.name])
                         bond_length = bond_lengths.get(bead_pair_rev, None)
-                    if not bond_length:
-                        raise ValueError(
-                                "The bond length for pair "
-                                f"{bead_pair} or {bead_pair_rev} "
-                                "is not found in the bond_lengths dict."
-                        )
+                        if not bond_length:
+                            raise ValueError(
+                                    "The bond length for pair "
+                                    f"{bead_pair} or {bead_pair_rev} "
+                                    "is not found in the bond_lengths dict."
+                            )
                     new_pos = last_bead.xyz[0] + (0, 0, bond_length)
                     next_bead.translate_to(new_pos)
                     self.add_bond([next_bead, last_bead])

--- a/hoomd_polymers/tests/test_molecules.py
+++ b/hoomd_polymers/tests/test_molecules.py
@@ -37,7 +37,57 @@ class TestMolecules(BaseTest):
         assert chain.n_particles == (monomer.n_particles*5)-8
 
     def test_lj_chain(self):
-        pass
+        cg_chain = LJ_chain(
+                length=3,
+                bead_sequence=["A"],
+                bead_mass={"A": 100},
+                bond_lengths={"A-A": 1.5}
+        )
+        assert cg_chain.n_particles == 3
+        assert cg_chain.mass == 300
+
+    def test_lj_chain_sequence(self):
+        cg_chain = LJ_chain(
+                length=3,
+                bead_sequence=["A", "B"],
+                bead_mass={"A": 100, "B": 150},
+                bond_lengths={"A-A": 1.5, "A-B": 1.0}
+        )
+        assert cg_chain.n_particles == 6
+        assert cg_chain.mass == 300 + 450
+
+    def test_lj_chain_sequence_bonds(self):
+        cg_chain = LJ_chain(
+                length=3,
+                bead_sequence=["A", "B"],
+                bead_mass={"A": 100, "B": 150},
+                bond_lengths={"A-A": 1.5, "A-B": 1.0}
+        )
+
+        cg_chain_rev = LJ_chain(
+                length=3,
+                bead_sequence=["A", "B"],
+                bead_mass={"A": 100, "B": 150},
+                bond_lengths={"A-A": 1.5, "B-A": 1.0}
+        )
+
+    def test_lj_chain_sequence_bad_bonds(self):
+        with pytest.raises(ValueError):
+            cg_chain = LJ_chain(
+                    length=3,
+                    bead_sequence=["A", "B"],
+                    bead_mass={"A": 100, "B": 150},
+                    bond_lengths={"A-A": 1.5}
+            )
+
+    def test_lj_chain_sequence_bad_mass(self):
+        with pytest.raises(ValueError):
+            cg_chain = LJ_chain(
+                    length=3,
+                    bead_sequence=["A", "B"],
+                    bead_mass={"A": 100},
+                    bond_lengths={"A-A": 1.5}
+            )
 
     def test_copolymer(self):
         pass


### PR DESCRIPTION
This PR makes the LJ chain class more flexible in terms of setting types, particle sequences, bond lengths and mass. The goal is to make it easier to run coarse-grained polymer simulations.  I've add a few unit tests for this class.