### PR TITLE
Add DisplacementCapped Integrator to simulation

### DIFF
--- a/hoomd_polymers/sim/simulation.py
+++ b/hoomd_polymers/sim/simulation.py
@@ -484,7 +484,8 @@ class Simulation(hoomd.simulation.Simulation):
         """
         self.set_integrator_method(
                 integrator_method=hoomd.md.methods.DisplacementCapped,
-                method_kwargs={"maximum_displacement": maximum_displacement}
+                method_kwargs={"filter": self.integrate_group,
+                               "maximum_displacement": maximum_displacement}
         )
         std_out_logger = StdOutLogger(n_steps=n_steps, sim=self)
         std_out_logger_printer = hoomd.update.CustomUpdater(

--- a/hoomd_polymers/sim/simulation.py
+++ b/hoomd_polymers/sim/simulation.py
@@ -474,7 +474,11 @@ class Simulation(hoomd.simulation.Simulation):
 
     def run_displacement_cap(self, n_steps, maximum_displacement=1e-3):
         """ NVE based integrator that Puts a cap on the maximum displacement per time step.
-
+        
+        DisplacementCapped method is mostly useful for initially relaxing a system with overlapping particles.
+        Putting a cap on the max particle displacement prevents Hoomd Particle Out of Box execption.
+        Once the system is relaxed, other run methods (NVE, NVT, etc) can be used.
+        
         Parameters:
         -----------
         n_steps : int, required

--- a/hoomd_polymers/sim/simulation.py
+++ b/hoomd_polymers/sim/simulation.py
@@ -472,6 +472,29 @@ class Simulation(hoomd.simulation.Simulation):
         self.run(n_steps)
         self.operations.updaters.remove(std_out_logger_printer)
 
+    def run_displacement_cap(self, n_steps, maximum_displacement=1e-3):
+        """ NVE based integrator that Puts a cap on the maximum displacement per time step.
+
+        Parameters:
+        -----------
+        n_steps : int, required
+            Number of steps to run during shrinking
+        maximum_displacement : maximum displacement per step (length)
+
+        """
+        self.set_integrator_method(
+                integrator_method=hoomd.md.methods.DisplacementCapped,
+                method_kwargs={"maximum_displacement": maximum_displacement}
+        )
+        std_out_logger = StdOutLogger(n_steps=n_steps, sim=self)
+        std_out_logger_printer = hoomd.update.CustomUpdater(
+                trigger=hoomd.trigger.Periodic(self._std_out_freq),
+                action=std_out_logger
+        )
+        self.operations.updaters.append(std_out_logger_printer)
+        self.run(n_steps)
+        self.operations.updaters.remove(std_out_logger_printer)
+
     def temperature_ramp(self, n_steps, kT_start, kT_final):
         return hoomd.variant.Ramp(
                 A=kT_start,

--- a/hoomd_polymers/tests/test_simulations.py
+++ b/hoomd_polymers/tests/test_simulations.py
@@ -77,6 +77,14 @@ class TestSimulate(BaseTest):
         sim.run_NVE(n_steps=500)
         assert isinstance(sim.method, hoomd.md.methods.NVE)
 
+    def test_displacement_cap(self, polyethylene_system):
+        sim = Simulation(
+                initial_state=polyethylene_system.hoomd_snapshot,
+                forcefield=polyethylene_system.hoomd_forcefield
+        )
+        sim.run_displacement_cap(n_steps=500, maximum_displacement=1e-4)
+        assert isinstance(sim.method, hoomd.md.methods.DisplacementCapped)
+
     def test_update_volume(self, polyethylene_system):
         sim = Simulation(
                 initial_state=polyethylene_system.hoomd_snapshot,


### PR DESCRIPTION
This PR adds `hoomd.md.methods.DisplacementCapped` integrator to the simulation class. This integrator is based on NVE and puts a cap on the max displacement (length) per timestep. 

This integrator is mostly helpful when dealing with system with overlapping particles that commonly causes particle out of the box error.  Using this integrator in the beginning helps with relaxing the system and overcoming the overlaps.